### PR TITLE
Allow for postgres id field (id instead of _id)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,8 @@ module.exports.service = function (options) {
           users.find({ query: { [prop]: uniques[prop].trim() /* , $limit: 1 */ } }) // 1 as unique
             .then(data => {
               const items = Array.isArray(data) ? data : data.data;
-              if (items.length > 1 || (items.length === 1 && items[0]._id !== ownId)) {
+              let id = items[0].id | items[0]._id;
+              if (items.length > 1 || (items.length === 1 && id !== ownId)) {
                 errs[prop] = 'Already taken.';
               }
 
@@ -177,7 +178,7 @@ module.exports.service = function (options) {
           }
 
           addVerifyProps(user, {}, (err, user1) => { // todo options not passed
-            users.update(user1._id, user1, {},
+            users.update(user1.id | user1._id, user1, {},
               (err1, user2) => { // careful, hooks may have stripped some fields out of user2
                 if (err1) { throw new errors.GeneralError(err1); }
 
@@ -229,7 +230,7 @@ module.exports.service = function (options) {
             ));
           }
 
-          users.update(user._id, user, {},
+          users.update(user.id | user._id, user, {},
             (err, user1) => {
               if (err) { throw new errors.GeneralError(err); }
               emailer('verify', clone(user), params, (err1) => {
@@ -266,7 +267,7 @@ module.exports.service = function (options) {
             user.resetExpires = Date.now() + resetDelay;
             user.resetToken = buf.toString('hex');
 
-            users.update(user._id, user, {},
+            users.update(user.id | user._id, user, {},
               (err1, user1) => {
                 if (err1) { throw new errors.GeneralError(err1); }
 
@@ -325,7 +326,7 @@ module.exports.service = function (options) {
               user.resetExpires = null;
               user.resetToken = null;
 
-              users.update(user._id, user, {},
+              users.update(user.id | user._id, user, {},
                 (err, user1) => {
                   if (err) { throw new errors.GeneralError(err); }
 
@@ -369,7 +370,7 @@ module.exports.service = function (options) {
             // update user information
             user.password = hook1.data.password;
 
-            users.update(user._id, user, {}, (err1, user1) => {
+            users.update(user.id | user._id, user, {}, (err1, user1) => {
               if (err1) {
                 throw new errors.GeneralError(err1);
               }
@@ -401,7 +402,7 @@ module.exports.service = function (options) {
         // update user information
         user.email = email;
 
-        users.update(user._id, user, {}, (err1, user2) => {
+        users.update(user.id | user._id, user, {}, (err1, user2) => {
           if (err1) {
             throw new errors.GeneralError(err1);
           }


### PR DESCRIPTION
Postgres does not use _id for ids. Passing undefined to users.find e al causes undesired behavior (triggers a MethodNotAllowed error in the users service, which in turn causes the request to the verifyReset service to timeout).
