### PR TITLE
udpdate example to properly require hooks instead of verifyResetHooks

### DIFF
--- a/example/src/services/user/hooks/index.js
+++ b/example/src/services/user/hooks/index.js
@@ -3,7 +3,7 @@
 
 const hooks = require('feathers-hooks');
 const auth = require('feathers-authentication').hooks;
-const verifyHooks = require('../../../hooks').verifyResetHooks; // NEW
+const verifyHooks = require('../../../hooks').hooks;
 
 exports.before = {
   all: [],


### PR DESCRIPTION
Hey, seems the example has an outdated line of code:

This: 
`const verifyHooks = require('../../../hooks').verifyResetHooks; // NEW`

Should be this:
`const verifyHooks = require('../../../hooks').hooks;`

Will probably help others avoid confusion :)
Thanks for the package!